### PR TITLE
Fix bug: properly close the session

### DIFF
--- a/pkg/proxy/session.go
+++ b/pkg/proxy/session.go
@@ -32,6 +32,7 @@ func newSession(session goetty.IOSession) *redisSession {
 }
 
 func (rs *redisSession) close() {
+	rs.session.Close()
 	rs.Lock()
 	rs.resps.Dispose()
 	log.Infof("redis-[%s]: closed", rs.addr)


### PR DESCRIPTION
If we do not close the connection, the connection will be in
`CLOSE_WAIT` state until proxy exit.

Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>